### PR TITLE
feat(auth): Refactor and add features

### DIFF
--- a/docs/docs/auth.md
+++ b/docs/docs/auth.md
@@ -84,3 +84,24 @@ The `AuthMiddleware` class will require authentication and authorization to all 
 
 ## `require_auth` decorator
 The `require_auth` decorator provides protection only to the routes it's applied to. This must be applied before, i.e. below, the route decorator so that no matter how the route function is called, the auth process will be applied.
+
+
+# Logging in
+Logging in is as simple as calling `auth.login()` with the correct kwargs for the backend. Using our PasswordAuth backend we would authenticate like so:
+```py title="src/main.py"
+@app.route("/login", methods=["GET", "POST"])
+async def protected_login_route(request: Request, as_superuser: bool = False):
+    if request.method == "POST":
+        await auth.login(
+            request,
+            username="test@email.com",
+            password="password",
+        )
+        return "logged in with PasswordAuth"
+    return "login page"
+```
+As you can see in the `auth.login()` function we don't have to specify the auth_handler (backend) if we are using the primary backend.
+
+
+# Accessing user data returned by the authentication backend
+The `auth.AuthSessionData` you returned from the Authentication Backend is stored on each request in the `Request.user` attribute and can be accessed anywhere you can access the request.

--- a/mojito/app.py
+++ b/mojito/app.py
@@ -16,7 +16,7 @@ from starlette.websockets import WebSocket
 
 from .globals import GlobalsMiddleware
 from .message_flash import MessageFlashMiddleware
-from .middleware.sessions import SessionMiddleware
+from .middleware.user_sessions import UserSessionMiddleware
 from .routing import AppRouter
 
 RouteFunctionType = Callable[[Request], Union[Awaitable[Response], Response]]
@@ -59,7 +59,7 @@ class Mojito(Starlette):
         )
         self.router = AppRouter(lifespan=lifespan)
         self.add_middleware(GlobalsMiddleware)
-        self.add_middleware(SessionMiddleware)
+        self.add_middleware(UserSessionMiddleware)
         self.add_middleware(MessageFlashMiddleware)
 
     def include_router(self, router: AppRouter):

--- a/mojito/auth.py
+++ b/mojito/auth.py
@@ -3,30 +3,35 @@ based authentication."""
 
 import functools
 import hashlib
+import sys
 import typing as t
+
+if sys.version_info >= (3, 10):  # pragma: no cover
+    from typing import ParamSpec
+else:  # pragma: no cover
+    from typing_extensions import ParamSpec
 
 from starlette.requests import Request
 from starlette.responses import RedirectResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from .config import Config
-from .globals import g
 
 
 class AuthSessionData(t.TypedDict):
-    "The authentication data stored on the session"
+    """The authentication data stored on the user session."""
 
     is_authenticated: bool
     auth_handler: t.Optional[str]
     'The name of the auth handler class used to authenticate the user. Ex: "PasswordAuth"'
     user_id: t.Any
     user: dict[str, t.Any]
-    """The user object. May contain any information about the user, such as name and user_id that
+    """The user object. May contain any metadata about the user, such as name and user_id that
     you want to be available anywhere with access to the request. Don't store any sensitive
-     information like passwords as all of this will be encoded and stored on the session but may
-     be decoded by anyone who inspects the cookie."""
+    information like passwords as all of this will be encoded and stored on the user session but may
+    be decoded by anyone who inspects the cookie."""
     permissions: list[str]
-    "permissions are used to authorize the user. Think of them as scopes in a JWT."
+    "Permissions are used to authorize the user. Think of them as scopes in a JWT."
 
 
 class BaseAuth(t.Protocol):
@@ -85,33 +90,37 @@ def include_auth_handler(auth_handler: type[BaseAuth], primary: bool = False):
         primary (bool, optional): Set the class as the primary/default auth handler. Defaults to False.
     """
     handler_name = auth_handler.__name__
-    print(f"set handler name: {handler_name}")
     _AuthConfig.auth_handlers[handler_name] = auth_handler
     if primary or len(_AuthConfig.auth_handlers) == 1:
         _AuthConfig.default_handler = handler_name
 
 
 async def _check_session_auth(request: Request, allowed_permissions: list[str]) -> bool:
-    if not request.session:
+    if not request.user:
         return False
-    session_data = AuthSessionData(
-        is_authenticated=request.session.get("is_authenticated", False),
-        auth_handler=request.session.get("auth_handler", _AuthConfig.default_handler),
-        user_id=request.session.get("user_id"),
-        user=request.session.get("user", {}),
-        permissions=request.session.get("permissions", []),
+    auth_session_data = AuthSessionData(
+        is_authenticated=request.user.get("is_authenticated", False),
+        auth_handler=request.user.get("auth_handler", _AuthConfig.default_handler),
+        user_id=request.user.get("user_id"),
+        user=request.user.get("user", {}),
+        permissions=request.user.get("permissions", []),
     )
-    if not session_data["is_authenticated"]:
+    if not auth_session_data["is_authenticated"]:
         # Revalidate on session exists but is not authenticated
         if not _AuthConfig.default_handler:
             raise NotImplementedError(
                 "an auth handler must be set using set_auth_handler"
             )
-        handler = _AuthConfig.auth_handlers[session_data["auth_handler"]]  # type:ignore
-        data = await handler().get_user(session_data["user_id"])
-        request.session.update(data)
+        handler = _AuthConfig.auth_handlers[auth_session_data["auth_handler"]]  # type:ignore
+        data = await handler().get_user(auth_session_data["user_id"])
+        request.user.update(data)
+    if (
+        Config.SUPERUSER_PERMISSION_NAME
+        and Config.SUPERUSER_PERMISSION_NAME in auth_session_data["permissions"]
+    ):
+        return True
     for allowed_permission in allowed_permissions:
-        if not allowed_permission in session_data["permissions"]:
+        if not allowed_permission in auth_session_data["permissions"]:
             return False
     return True
 
@@ -162,36 +171,47 @@ class AuthMiddleware:
         await self.app(scope, receive, send_wrapper)
 
 
-def require_auth(
-    allow_permissions: list[str] = [], redirect_url: t.Optional[str] = None
-):
+_P = ParamSpec("_P")
+
+
+def requires(
+    scopes: t.Union[str, t.Sequence[str]] = [],
+    redirect_url: t.Optional[str] = None,
+) -> t.Callable[[t.Callable[_P, t.Any]], t.Callable[_P, t.Any]]:
     """Decorator to require that the user is authenticated and optionally check that the user has
     the required auth scopes before accessing the resource. Redirect to the configured
     login_url if one is set, or to redirect_url if one is given.
 
     Args:
-        scopes (Optional[list[str]]): Auth scopes to verify the user has. Defaults to None.
+        scopes (list[str]): Auth scopes to verify the user has. Defaults to [].
         redirect_url (Optional[list[str]]): Redirect to this url rather than the configured
             login_url.
     """
-    # This decorator must be applied below the route definition decorator so that it will wrap the
-    # endpoint function before the route decorator will. This decorator will pass all arg straight
-    # through after verifying authentication or else it will return a redirect response.
+    scopes_list = [scopes] if isinstance(scopes, str) else list(scopes)
 
-    def wrapper(func: t.Callable[..., t.Any]):
+    def decorator(
+        func: t.Callable[_P, t.Any],
+    ) -> t.Callable[..., t.Awaitable[t.Any]]:
+        # Handle async request/response functions.
         @functools.wraps(func)
-        async def requires_auth_function(*args: t.Any, **kwargs: dict[str, t.Any]):
-            request = g.request
-            assert isinstance(request, Request)
-            REDIRECT_URL = redirect_url if redirect_url else Config.LOGIN_URL
-            allow = await _check_session_auth(request, allow_permissions)
-            if not allow:
+        async def wrapper(
+            request: Request, *args: _P.args, **kwargs: _P.kwargs
+        ) -> t.Any:
+            if not isinstance(request, Request):  # type: ignore
+                raise Exception(
+                    "The Request must be the first argument to the function when using the `@requires` decorator"
+                )
+            if not await _check_session_auth(request, scopes_list):
+                REDIRECT_URL = redirect_url if redirect_url else Config.LOGIN_URL
                 return RedirectResponse(REDIRECT_URL, 302)
-            return func(*args, **kwargs)
+            if isinstance(func, t.Awaitable):  # type: ignore
+                return await func(request, *args, **kwargs)
+            else:
+                return func(request, *args, **kwargs)  # type: ignore
 
-        return requires_auth_function
+        return wrapper
 
-    return wrapper
+    return decorator
 
 
 def hash_password(password: str) -> str:
@@ -209,6 +229,7 @@ def hash_password(password: str) -> str:
 async def login(
     request: Request,
     auth_handler: t.Optional[type[BaseAuth]] = None,
+    persist_session: bool = True,
     **kwargs: t.Any,
 ):
     """Login user and create an authenticated session.
@@ -217,6 +238,9 @@ async def login(
         request (Request): the request
         auth_handler (type[BaseAuth], optional): Auth class to login with.
             Defaults to the default auth handler configured using set_auth_handler().
+        persist_session (bool): maintain the session cookie until the maximum age defined
+            in the USER_SESSION_EXPIRES environment variable. If false, the cookie is set to
+            expire at the end of the browser session. Default True.
 
     Returns:
         AuthSessionData: The data set on the session. None if invalid login.
@@ -227,10 +251,12 @@ async def login(
     result = await handler.authenticate(request, **kwargs)
     if not result:
         return None
-    request.session.update(result)
+    request.user.update(result)
+    if not persist_session:
+        request.user["persist_session"] = True
     return result
 
 
 def logout(request: Request):
     """Expire the current user session."""
-    request.session.clear()
+    request.user.clear()

--- a/mojito/config.py
+++ b/mojito/config.py
@@ -1,13 +1,41 @@
 # TODO - Load config from os if it exists
+import os
+from typing import Optional
+
+
 class Config:
-    SECRET_KEY: str = "poaiuvnepwoijsoxmkcpaoiu"
-    MESSAGE_FLASH_COOKIE: str = "flash_messages"
-    LOGIN_URL: str = "/login"
-    SESSION_EXPIRES: int = 60 * 60 * 24 * 7  # 1wk default
-    "In seconds. How long the session cookie should be allowed to exist before being replaced."
-    SESSION_REVALIDATE_AFTER: int = 0  # Revalidate on every request
-    """In seconds.
-    How long the session cookie should be considered valid before running revalidation
-      on the users authentication. Within this time, as long as the cookie signature is
-      valid, the user will be considered authenticated and all the cookie data will be used.
-      """
+    SECRET_KEY: str = os.getenv("SECRET_KEY", "")
+    """Secret key used to encrypt sensitive data.
+    
+    Defaults to empty string.
+    """
+    MESSAGE_FLASH_COOKIE: str = os.getenv("MESSAGE_FLASH_COOKIE", "mo_flash_messages")
+    """Name of the cookie message flash data will be stored to.
+    
+    Defaults to `mo_flash_messages`
+    """
+    LOGIN_URL: str = os.getenv("LOGIN_URL", "/login")
+    "Defaults to `/login`"
+    USER_SESSION_COOKIE: str = os.getenv("USER_SESSION_COOKIE", "mo_user_session")
+    """Name of the user session cookie.
+    
+    Defaults to `mo_user_session`
+    """
+    USER_SESSION_EXPIRES: int = int(os.getenv("SESSION_EXPIRES", 60 * 60 * 24 * 7))
+    """In seconds. How long the session cookie should be allowed to exist before being replaced.
+    
+    Defaults to 1 week.
+    """
+    USER_SESSION_REVALIDATE_AFTER: int = int(os.getenv("SESSION_REVALIDATE_AFTER", 0))
+    """In seconds. How long the session cookie should be considered valid before running revalidation
+    on the users authentication. Within this time, as long as the cookie signature is
+    valid, the user will be considered authenticated and all the cookie data will be used.
+
+    Defaults to 0, revalidate on every request.
+    """
+    SUPERUSER_PERMISSION_NAME: Optional[str] = os.getenv("SUPERUSER_PERMISSION_NAME")
+    """The name of the superuser permission.
+
+    When present in the Request.user.permissions, this role will bypass any permission (authorization) 
+    requirements defined for a route function. This permission does not bypass authentication.
+    """

--- a/mojito/middleware/user_sessions.py
+++ b/mojito/middleware/user_sessions.py
@@ -7,7 +7,7 @@ from base64 import b64decode, b64encode
 
 import itsdangerous
 from itsdangerous.exc import BadSignature
-from starlette.datastructures import MutableHeaders, Secret
+from starlette.datastructures import MutableHeaders
 from starlette.requests import HTTPConnection
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -17,23 +17,25 @@ if typing.TYPE_CHECKING:
     from ..auth import AuthSessionData
 
 
-class SessionMiddleware:
+class UserSessionMiddleware:
+    """Adds `user` data to the Request object.
+
+    Used for authentication and session management.
+    """
+
+    # Works nearly the same as Starlettes SessionMiddleware but without some of the configuration options
     def __init__(
         self,
         app: ASGIApp,
-        secret_key: str | Secret = config.Config.SECRET_KEY,
-        session_cookie: str = "session",
-        max_age: int | None = config.Config.SESSION_EXPIRES,
-        path: str = "/",
         same_site: typing.Literal["lax", "strict", "none"] = "strict",
         https_only: bool = False,
         domain: str | None = None,
     ) -> None:
         self.app = app
-        self.signer = itsdangerous.TimestampSigner(str(secret_key))
-        self.session_cookie = session_cookie
-        self.max_age = max_age
-        self.path = path
+        self.signer = itsdangerous.TimestampSigner(config.Config.SECRET_KEY)
+        self.cookie_name = config.Config.USER_SESSION_COOKIE
+        self.max_age = config.Config.USER_SESSION_EXPIRES
+        self.path = "/"
         self.security_flags = "httponly; samesite=" + same_site
         if https_only:  # Secure flag can be used with HTTPS only
             self.security_flags += "; secure"
@@ -46,10 +48,11 @@ class SessionMiddleware:
             return
 
         connection = HTTPConnection(scope)
-        initial_session_was_empty = True
+        initial_user_was_empty = True
 
-        if self.session_cookie in connection.cookies:
-            data = connection.cookies[self.session_cookie].encode("utf-8")
+        if self.cookie_name in connection.cookies:
+            # RECEIVE COOKIE
+            data = connection.cookies[self.cookie_name].encode("utf-8")
             try:
                 data_bytes, timestamp = self.signer.unsign(
                     data, max_age=self.max_age, return_timestamp=True
@@ -57,39 +60,42 @@ class SessionMiddleware:
                 data_decoded = b64decode(data_bytes)
                 json_data: AuthSessionData = json.loads(data_decoded)
                 reauthenticate_after = timestamp + datetime.timedelta(
-                    seconds=config.Config.SESSION_REVALIDATE_AFTER
+                    seconds=config.Config.USER_SESSION_REVALIDATE_AFTER
                 )
                 if datetime.datetime.now(datetime.timezone.utc) > reauthenticate_after:
                     json_data["is_authenticated"] = (
                         False  # Force reauthentication if session needs revalidated
                     )
-                scope["session"] = json_data
-                initial_session_was_empty = False
+                scope["user"] = json_data
+                initial_user_was_empty = False
             except BadSignature:
-                scope["session"] = {}
+                scope["user"] = {}
         else:
-            scope["session"] = {}
+            scope["user"] = {}
 
         async def send_wrapper(message: Message) -> None:
+            # SEND COOKIE
             if message["type"] == "http.response.start":
-                if scope["session"]:
-                    # We have session data to persist.
-                    data = b64encode(json.dumps(scope["session"]).encode("utf-8"))
+                if scope["user"]:
+                    # We have user data to persist.
+                    data = b64encode(json.dumps(scope["user"]).encode("utf-8"))
                     data = self.signer.sign(data)
                     headers = MutableHeaders(scope=message)
-                    header_value = "{session_cookie}={data}; path={path}; {max_age}{security_flags}".format(  # noqa E501
-                        session_cookie=self.session_cookie,
+                    header_value = "{cookie_name}={data}; path={path}; {max_age}{security_flags}".format(  # noqa E501
+                        cookie_name=self.cookie_name,
                         data=data.decode("utf-8"),
                         path=self.path,
-                        max_age=f"Max-Age={self.max_age}; " if self.max_age else "",
+                        max_age=f"Max-Age={self.max_age}; "
+                        if scope["user"].get("persist_session", False)
+                        else "",
                         security_flags=self.security_flags,
                     )
                     headers.append("Set-Cookie", header_value)
-                elif not initial_session_was_empty:
-                    # The session has been cleared.
+                elif not initial_user_was_empty:
+                    # The user has been cleared.
                     headers = MutableHeaders(scope=message)
-                    header_value = "{session_cookie}={data}; path={path}; {expires}{security_flags}".format(  # noqa E501
-                        session_cookie=self.session_cookie,
+                    header_value = "{cookie_name}={data}; path={path}; {expires}{security_flags}".format(  # noqa E501
+                        cookie_name=self.cookie_name,
                         data="null",
                         path=self.path,
                         expires="expires=Thu, 01 Jan 1970 00:00:00 GMT; ",


### PR DESCRIPTION
* Remove use of SessionMiddleware in favor of custom UserSessionMiddleware for creating the Request.user attribute
* Refactor auth to use Request.user object rather than Request.session
* Remove use of globals.g in auth functions in favor of direct Request access. This now requried the Request be the first argument of each
* Refactor require_auth to requires and remove dependency on globals.g
* Add config setting for SUPERUSER_PERMISSION_NAME to allow all actions to any authenticated user with that permission
* Add argument to `auth.login()` for persist_session

BREAKING CHANGE: